### PR TITLE
chore: add mergify auto-merge for renovate PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,3 +6,19 @@ pull_request_rules:
       label:
         toggle:
           - conflict
+
+  - name: Automatic merge on approval
+    conditions:
+      - '#commits-behind=0'
+      - or:
+          - '#approved-reviews-by>=1'
+          - label=ci:auto-merge
+      - not:
+          and:
+            - 'head*=renovate/lockfile-maintenance-*'
+            - 'created-at>24h ago'
+      - base=master
+      - check-success=pre-commit
+    actions:
+      merge:
+        method: squash

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,10 @@
   "extends": [
     "local>trim21/renovate-config",
     "local>trim21/renovate-config:monthly"
-  ]
+  ],
+  "labels": [
+    "ci:auto-merge",
+    "dependencies"
+  ],
+  "prConcurrentLimit": 3
 }


### PR DESCRIPTION
Summary:\n- add Mergify automatic merge rule (approval or ci:auto-merge label)\n- require check-success pre-commit on master\n- add Renovate labels ci:auto-merge and dependencies\n- set Renovate prConcurrentLimit to 3